### PR TITLE
adding ranking bot

### DIFF
--- a/discord/Rank/bot_command.py
+++ b/discord/Rank/bot_command.py
@@ -1,0 +1,34 @@
+from count_func import call_count
+import json
+import discord
+from discord.ext import commands
+from last_week import recent
+
+client = discord.Client()
+
+bot = commands.Bot(command_prefix='t!')
+
+def read_token():
+    with open("token.txt","r") as f:
+        lines = f.readlines()
+        return lines[0].strip()
+
+token = read_token()
+
+@bot.command()
+async def source(ctx):
+    await ctx.send('asdf')
+    call_count('asdf')
+
+@bot.command(name='top')
+async def top(ctx):
+    anime_list = json.load(open('frequency.json', 'r'))
+    top = sorted(anime_list.items(), key=lambda x: x[1], reverse=True)
+    for x in top:
+        await ctx.send(f'{x}')
+
+
+@bot.command(name='weekly')
+async def weekly(ctx):
+    for x in top_week:
+        await ctx.send(f'{x}')

--- a/discord/Rank/count_func.py
+++ b/discord/Rank/count_func.py
@@ -1,0 +1,35 @@
+import json
+import datetime
+import pytz
+
+def call_count (name):
+    return count(name)
+    return day_count(name)
+
+
+def count(name):
+    try:
+        anime_list = json.load(open('frequency.json', 'r'))
+    except:
+        anime_list = {}
+
+    anime_list[name] = anime_list.get(name, 0) + 1
+
+    result = json.dumps(anime_list, indent=1)
+    with open("frequency.json", "w") as outfile:
+        outfile.write(result)
+
+
+def day_count(name):
+    current_time = datetime.datetime.now(pytz.timezone('Asia/Bangkok')).strftime("%Y-%m-%d")
+
+    try:
+        weekly_anime_list = json.load(open('daily_frequency.json', 'r'))
+    except:
+        weekly_anime_list = {}
+    weekly_anime_list[current_time] = weekly_anime_list.get(current_time, {})
+    weekly_anime_list[current_time][name] = weekly_anime_list[current_time].get(name, 0) + 1
+
+    weekly_result = json.dumps(weekly_anime_list, indent=1)
+    with open("daily_frequency.json", "w") as outfile:
+        outfile.write(weekly_result)

--- a/discord/Rank/last_week.py
+++ b/discord/Rank/last_week.py
@@ -1,0 +1,11 @@
+from count_func import call_count
+import json
+
+def recent():
+    weekly_anime_list = json.load(open('daily_frequency.json', 'r'))
+    week = {}
+    for date, v in sorted(weekly_anime_list.items(), key=lambda x: x[0])[-7:]:
+        for i, j in v.items():
+            temp[i] = temp.get(i, 0) + j
+    top_week = sorted(week.items(), key=lambda x: x[1], reverse=True)[:5]
+    return top_week

--- a/ranking/top_bot.py
+++ b/ranking/top_bot.py
@@ -1,0 +1,79 @@
+import discord
+from discord.ext import commands
+import json
+import datetime
+import pytz
+
+client = discord.Client()
+
+bot = commands.Bot(command_prefix='t!')
+
+def read_token():
+    with open("token.txt","r") as f:
+        lines = f.readlines()
+        return lines[0].strip()
+
+token = read_token()
+
+@bot.command()
+async def source(ctx):
+    await ctx.send('fgh')
+    call_count('fgh')
+
+
+def call_count (name):
+    count(name)
+    weekly(name)
+
+
+def count(name):
+    try:
+        anime_list = json.load(open('frequency.json', 'r'))
+    except:
+        anime_list = {}
+
+    anime_list[name] = anime_list.get(name, 0) + 1
+
+    result = json.dumps(anime_list, indent=1)
+    with open("frequency.json", "w") as outfile:
+        outfile.write(result)
+
+'''t!source'''
+'''t!count{asdasdasd}'''
+
+def weekly(name):
+    current_time = datetime.datetime.now(pytz.timezone('Asia/Bangkok')).strftime("%Y-%m-%d")
+
+    try:
+        weekly_anime_list = json.load(open('daily_frequency.json', 'r'))
+    except:
+        weekly_anime_list = {}
+    weekly_anime_list[current_time] = weekly_anime_list.get(current_time, {})
+    weekly_anime_list[current_time][name] = weekly_anime_list[current_time].get(name, 0) + 1
+
+    weekly_result = json.dumps(weekly_anime_list, indent=1)
+    with open("daily_frequency.json", "w") as outfile:
+        outfile.write(weekly_result)
+
+
+@bot.command()
+async def top5(ctx):
+    anime_list = json.load(open('frequency.json', 'r'))
+    top = sorted(anime_list.items(), key=lambda x: x[1], reverse=True)
+    for x in top:
+        await ctx.send(f'{x}')
+
+
+@bot.command()
+async def week_rank(ctx):
+    weekly_anime_list = json.load(open('daily_frequency.json', 'r'))
+    temp = {}
+    for date, v in sorted(weekly_anime_list.items(), key=lambda x: x[0])[-7:]:
+        for i, j in v.items():
+            temp[i] = temp.get(i, 0) + j
+    top = sorted(temp.items(), key=lambda x: x[1], reverse=True)
+    for x in top:
+        await ctx.send(f'{x}')
+
+bot.run(token)
+


### PR DESCRIPTION
Adding the ranking bot that will count the amount of time the name of the anime is being replied by source command, both weekly and daily. The source command in this is a dummy so the main one needs to be changed to return name and also use call_count. It's not displaying only the top 5 but every single anime being mentioned by the source command.